### PR TITLE
Feature/simulation configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(roboteam_networking STATIC
     "src/RobotFeedbackNetworker.cpp"
     "src/SettingsNetworker.cpp"
     "src/WorldNetworker.cpp"
+    "src/SimulationConfigurationNetworker.cpp"
 )
 
 target_include_directories(roboteam_networking PUBLIC "include")

--- a/include/SimulationConfigurationNetworker.hpp
+++ b/include/SimulationConfigurationNetworker.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <proto/SimulationConfiguration.pb.h>
+#include <utils/Publisher.hpp>
+#include <utils/Subscriber.hpp>
+
+#include <functional>
+
+namespace rtt::net {
+
+class SimulationConfigurationPublisher : private utils::Publisher<proto::SimulationConfiguration> {
+   public:
+    SimulationConfigurationPublisher();
+
+    bool publish(const proto::SimulationConfiguration& configuration);
+};
+
+class SimulationConfigurationSubscriber : private rtt::net::utils::Subscriber<proto::SimulationConfiguration> {
+   public:
+    SimulationConfigurationSubscriber(const std::function<void(const proto::SimulationConfiguration&)>& configuration);
+};
+
+}  // namespace rtt::net

--- a/include/utils/Channels.hpp
+++ b/include/utils/Channels.hpp
@@ -12,12 +12,13 @@ enum ChannelType {
     // AI to Robothub
     ROBOT_COMMANDS_BLUE_CHANNEL,
     ROBOT_COMMANDS_YELLOW_CHANNEL,
+    SIMULATION_CONFIGURATION_CHANNEL,
 
     // Robothub to World
     ROBOT_FEEDBACK_CHANNEL,
 
-    // Robothub to AI
-    WORLD_CHANNEL,
+    // World to AI
+    WORLD_CHANNEL
 };
 
 extern const std::map<ChannelType, Channel> CHANNELS;

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -19,6 +19,7 @@ protobuf_generate_cpp(NET_PROTO_SRCS NET_PROTO_HDRS
     "Setting.proto"
     "RobotParameters.proto"
     "AICommand.proto"
+    "SimulationConfiguration.proto"
 )
 
 add_library(roboteam_networking_proto STATIC "${NET_PROTO_SRCS}" "${NET_PROTO_HDRS}")

--- a/proto/SimulationConfiguration.proto
+++ b/proto/SimulationConfiguration.proto
@@ -28,6 +28,7 @@ message SimulationRobotLocation {
     float angular_velocity = 7; // In radians per second
     float orientation = 8; // In radians, counter-clockwise, starting at +x(right)
     bool present_on_field = 9; // Can make robot disappear
+    bool by_force = 10; // Will make sure the robot eventually ends up at the given coordinates by setting a velocity
 }
 
 // Robot properties
@@ -57,7 +58,7 @@ message SimulationRobotProperties {
 
 message SimulationConfiguration {
     SimulationBallLocation ball_location = 1;
-    repeated SimulationRobotLocation robot_location = 2;
+    repeated SimulationRobotLocation robot_locations = 2;
     repeated SimulationRobotProperties robot_properties = 3;
     float simulation_speed = 4;
     uint32 vision_port = 5;

--- a/proto/SimulationConfiguration.proto
+++ b/proto/SimulationConfiguration.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+import "Vector2f.proto";
+
+package proto;
+
+// Ball location
+message SimulationBallLocation {
+    float x = 1; // Center of field is 0.0, from goal to goal in meters
+    float y = 2; // Center of field is 0.0, form sideline to sideline in meters
+    float z = 3; // Field is at 0.0, from underground to the sky in meters
+    float xVelocity = 4;
+    float yVelocity = 5;
+    float zVelocity = 6;
+    bool velocityInRolling = 7; // Will convert the given velocity into rolling speed
+    bool teleportSafely = 8; // Will make sure other robots are moved out of the way, and will not collide with it
+    bool byForce = 9; // Will make sure the ball eventually ends up at the given coordinates by setting a velocity
+}
+
+// Robot location
+message SimulationRobotLocation {
+    uint32 id = 1;
+    bool isTeamYellow = 2; // TODO: Make use of enums
+    float x = 3; // Center of field is 0.0, from goal to goal in meters
+    float y = 4; // Center of field is 0.0, form sideline to sideline in meters
+    float xVelocity = 5;
+    float yVelocity = 6;
+    float angularVelocity = 7; // In radians per second
+    float orientation = 8; // In radians, counter-clockwise, starting at +x(right)
+    bool presentOnField = 9; // Can make robot disappear
+}
+
+// Robot properties
+message SimulationRobotProperties {
+    uint32 id = 1;
+    bool isTeamYellow = 2; // TODO: Make use of enums
+    // Units in meters, kilograms, radians, m/s or m/s^2.
+    float radius = 3;
+    float height = 4;
+    float mass = 5;
+    float maxKickSpeed = 6;
+    float maxChipSpeed = 7;
+    float centerToDribblerDistance = 8;
+    // Robot limits
+    float maxAcceleration = 9;
+    float maxAngularAcceleration = 10;
+    float maxDeceleration = 11;
+    float maxAngularDeceleration = 12;
+    float maxVelocity = 13;
+    float maxAngularVelocity = 14;
+    // Wheel angles. Counter-clockwise starting from dribbler
+    float frontRightWheelAngle = 15;
+    float backRightWheelAngle = 16;
+    float backLeftWheelAngle = 17;
+    float frontLeftWheelAngle = 18;
+}
+
+message SimulationConfiguration {
+    SimulationBallLocation ballLocation = 1;
+    repeated SimulationRobotLocation robotLocation = 2;
+    repeated SimulationRobotProperties robotProperties = 3;
+    float simulationSpeed = 4;
+    uint32 visionPort = 5;
+
+    // TODO: Add field geometry to this configuration
+}

--- a/proto/SimulationConfiguration.proto
+++ b/proto/SimulationConfiguration.proto
@@ -9,58 +9,58 @@ message SimulationBallLocation {
     float x = 1; // Center of field is 0.0, from goal to goal in meters
     float y = 2; // Center of field is 0.0, form sideline to sideline in meters
     float z = 3; // Field is at 0.0, from underground to the sky in meters
-    float xVelocity = 4;
-    float yVelocity = 5;
-    float zVelocity = 6;
-    bool velocityInRolling = 7; // Will convert the given velocity into rolling speed
-    bool teleportSafely = 8; // Will make sure other robots are moved out of the way, and will not collide with it
-    bool byForce = 9; // Will make sure the ball eventually ends up at the given coordinates by setting a velocity
+    float x_velocity = 4;
+    float y_velocity = 5;
+    float z_velocity = 6;
+    bool velocity_in_rolling = 7; // Will convert the given velocity into rolling speed
+    bool teleport_safely = 8; // Will make sure other robots are moved out of the way, and will not collide with it
+    bool by_force = 9; // Will make sure the ball eventually ends up at the given coordinates by setting a velocity
 }
 
 // Robot location
 message SimulationRobotLocation {
     uint32 id = 1;
-    bool isTeamYellow = 2; // TODO: Make use of enums
+    bool is_team_yellow = 2; // TODO: Make use of enums
     float x = 3; // Center of field is 0.0, from goal to goal in meters
     float y = 4; // Center of field is 0.0, form sideline to sideline in meters
-    float xVelocity = 5;
-    float yVelocity = 6;
-    float angularVelocity = 7; // In radians per second
+    float x_velocity = 5;
+    float y_velocity = 6;
+    float angular_velocity = 7; // In radians per second
     float orientation = 8; // In radians, counter-clockwise, starting at +x(right)
-    bool presentOnField = 9; // Can make robot disappear
+    bool present_on_field = 9; // Can make robot disappear
 }
 
 // Robot properties
 message SimulationRobotProperties {
     uint32 id = 1;
-    bool isTeamYellow = 2; // TODO: Make use of enums
+    bool is_team_yellow = 2; // TODO: Make use of enums
     // Units in meters, kilograms, radians, m/s or m/s^2.
     float radius = 3;
     float height = 4;
     float mass = 5;
-    float maxKickSpeed = 6;
-    float maxChipSpeed = 7;
-    float centerToDribblerDistance = 8;
+    float max_kick_speed = 6;
+    float max_chip_speed = 7;
+    float center_to_dribbler_distance = 8;
     // Robot limits
-    float maxAcceleration = 9;
-    float maxAngularAcceleration = 10;
-    float maxDeceleration = 11;
-    float maxAngularDeceleration = 12;
-    float maxVelocity = 13;
-    float maxAngularVelocity = 14;
+    float max_acceleration = 9;
+    float max_angular_acceleration = 10;
+    float max_deceleration = 11;
+    float max_angular_deceleration = 12;
+    float max_velocity = 13;
+    float max_angular_velocity = 14;
     // Wheel angles. Counter-clockwise starting from dribbler
-    float frontRightWheelAngle = 15;
-    float backRightWheelAngle = 16;
-    float backLeftWheelAngle = 17;
-    float frontLeftWheelAngle = 18;
+    float front_right_wheel_angle = 15;
+    float back_right_wheel_angle = 16;
+    float back_left_wheel_angle = 17;
+    float front_left_wheel_angle = 18;
 }
 
 message SimulationConfiguration {
-    SimulationBallLocation ballLocation = 1;
-    repeated SimulationRobotLocation robotLocation = 2;
-    repeated SimulationRobotProperties robotProperties = 3;
-    float simulationSpeed = 4;
-    uint32 visionPort = 5;
+    SimulationBallLocation ball_location = 1;
+    repeated SimulationRobotLocation robot_location = 2;
+    repeated SimulationRobotProperties robot_properties = 3;
+    float simulation_speed = 4;
+    uint32 vision_port = 5;
 
     // TODO: Add field geometry to this configuration
 }

--- a/src/SimulationConfigurationNetworker.cpp
+++ b/src/SimulationConfigurationNetworker.cpp
@@ -1,0 +1,11 @@
+#include <SimulationConfigurationNetworker.hpp>
+
+namespace rtt::net {
+
+SimulationConfigurationPublisher::SimulationConfigurationPublisher() : utils::Publisher<proto::SimulationConfiguration>(utils::ChannelType::SIMULATION_CONFIGURATION_CHANNEL) {}
+
+bool SimulationConfigurationPublisher::publish(const proto::SimulationConfiguration& config) { return this->send(config); }
+
+SimulationConfigurationSubscriber::SimulationConfigurationSubscriber(const std::function<void(const proto::SimulationConfiguration&)>& callback) : utils::Subscriber<proto::SimulationConfiguration>(utils::ChannelType::SIMULATION_CONFIGURATION_CHANNEL, callback) {}
+
+}  // namespace rtt::net

--- a/src/utils/Channels.cpp
+++ b/src/utils/Channels.cpp
@@ -11,7 +11,9 @@ const std::map<ChannelType, Channel> CHANNELS = {
 
     {ROBOT_FEEDBACK_CHANNEL, {"robot_feedback", "127.0.0.1", "5561"}},
 
-    {WORLD_CHANNEL, {"world", "127.0.0.1", "5558"}}
+    {WORLD_CHANNEL, {"world", "127.0.0.1", "5558"}},
+
+    {SIMULATION_CONFIGURATION_CHANNEL, {"simulation_configuration", "127.0.0.1", "5562"}}
 };
 
 }  // namespace rtt::net::utils


### PR DESCRIPTION
This PR adds a networker class for publishing and subscribing to Simulation Configuration commands. These commands can edit the locations of robots in a simulator, edit the physical properties and limitations of the robots, change the position of the ball, change the simulation speed etc.

Even though this PR is not dependent on another PR, this would be a very useless PR if the [PR in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/pull/49) would not be merged.