### PR TITLE
Return bytes sent on Publish function

### DIFF
--- a/include/RobotCommandsNetworker.hpp
+++ b/include/RobotCommandsNetworker.hpp
@@ -12,8 +12,8 @@ class RobotCommandsBluePublisher : private utils::Publisher {
    public:
     RobotCommandsBluePublisher();
 
-    // Publishes the given robot commands on the blue channel. Returns success
-    bool publish(const rtt::RobotCommands& commands);
+    // Publishes the given robot commands on the blue channel. Returns bytes sent, -1 on failure
+    std::size_t publish(const rtt::RobotCommands& commands);
 };
 
 class RobotCommandsBlueSubscriber : private utils::Subscriber {
@@ -29,8 +29,8 @@ class RobotCommandsYellowPublisher : private utils::Publisher {
    public:
     RobotCommandsYellowPublisher();
 
-    // Publishes the given robot commands on the yellow channel. Returns success
-    bool publish(const rtt::RobotCommands& commands);
+    // Publishes the given robot commands on the yellow channel. Returns bytes sent, -1 on failure
+    std::size_t publish(const rtt::RobotCommands& commands);
 };
 
 class RobotCommandsYellowSubscriber : private utils::Subscriber {

--- a/include/RobotCommandsNetworker.hpp
+++ b/include/RobotCommandsNetworker.hpp
@@ -12,7 +12,7 @@ class RobotCommandsBluePublisher : private utils::Publisher {
    public:
     RobotCommandsBluePublisher();
 
-    // Publishes the given robot commands on the blue channel. Returns bytes sent, -1 on failure
+    // Publishes the given robot commands on the blue channel. Returns bytes sent, 0 on failure
     std::size_t publish(const rtt::RobotCommands& commands);
 };
 
@@ -29,7 +29,7 @@ class RobotCommandsYellowPublisher : private utils::Publisher {
    public:
     RobotCommandsYellowPublisher();
 
-    // Publishes the given robot commands on the yellow channel. Returns bytes sent, -1 on failure
+    // Publishes the given robot commands on the yellow channel. Returns bytes sent, 0 on failure
     std::size_t publish(const rtt::RobotCommands& commands);
 };
 

--- a/include/RobotFeedbackNetworker.hpp
+++ b/include/RobotFeedbackNetworker.hpp
@@ -12,7 +12,7 @@ class RobotFeedbackPublisher : private utils::Publisher {
    public:
     RobotFeedbackPublisher();
 
-    // Publishes the given robot feedback. Returns bytes sent, -1 on failure
+    // Publishes the given robot feedback. Returns bytes sent, 0 on failure
     std::size_t publish(const rtt::RobotsFeedback& feedback);
 };
 

--- a/include/RobotFeedbackNetworker.hpp
+++ b/include/RobotFeedbackNetworker.hpp
@@ -12,8 +12,8 @@ class RobotFeedbackPublisher : private utils::Publisher {
    public:
     RobotFeedbackPublisher();
 
-    // Publishes the given robot feedback. Returns success
-    bool publish(const rtt::RobotsFeedback& feedback);
+    // Publishes the given robot feedback. Returns bytes sent, -1 on failure
+    std::size_t publish(const rtt::RobotsFeedback& feedback);
 };
 
 class RobotFeedbackSubscriber : private utils::Subscriber {

--- a/include/SettingsNetworker.hpp
+++ b/include/SettingsNetworker.hpp
@@ -11,7 +11,7 @@ class SettingsPublisher : private utils::Publisher {
    public:
     SettingsPublisher();
 
-    // Publishes the given settings. Returns bytes sent, -1 on failure
+    // Publishes the given settings. Returns bytes sent, 0 on failure
     std::size_t publish(const proto::Setting& settings);
 };
 

--- a/include/SettingsNetworker.hpp
+++ b/include/SettingsNetworker.hpp
@@ -11,8 +11,8 @@ class SettingsPublisher : private utils::Publisher {
    public:
     SettingsPublisher();
 
-    // Publishes the given settings. Returns success
-    bool publish(const proto::Setting& settings);
+    // Publishes the given settings. Returns bytes sent, -1 on failure
+    std::size_t publish(const proto::Setting& settings);
 };
 
 class SettingsSubscriber : private utils::Subscriber {

--- a/include/SimulationConfigurationNetworker.hpp
+++ b/include/SimulationConfigurationNetworker.hpp
@@ -11,7 +11,7 @@ class SimulationConfigurationPublisher : private utils::Publisher {
    public:
     SimulationConfigurationPublisher();
 
-    // Publishes the given simulation configuration message. Returns bytes sent, -1 on failure
+    // Publishes the given simulation configuration message. Returns bytes sent, 0 on failure
     std::size_t publish(const proto::SimulationConfiguration& configuration);
 };
 

--- a/include/SimulationConfigurationNetworker.hpp
+++ b/include/SimulationConfigurationNetworker.hpp
@@ -11,8 +11,8 @@ class SimulationConfigurationPublisher : private utils::Publisher {
    public:
     SimulationConfigurationPublisher();
 
-    // Publishes the given simulation configuration message. Returns success
-    bool publish(const proto::SimulationConfiguration& configuration);
+    // Publishes the given simulation configuration message. Returns bytes sent, -1 on failure
+    std::size_t publish(const proto::SimulationConfiguration& configuration);
 };
 
 class SimulationConfigurationSubscriber : private rtt::net::utils::Subscriber {

--- a/include/WorldNetworker.hpp
+++ b/include/WorldNetworker.hpp
@@ -11,7 +11,7 @@ class WorldPublisher : private utils::Publisher {
    public:
     WorldPublisher();
 
-    // Publishes the given world. Returns bytes sent, -1 on failure
+    // Publishes the given world. Returns bytes sent, 0 on failure
     std::size_t publish(const proto::State& world);
 };
 

--- a/include/WorldNetworker.hpp
+++ b/include/WorldNetworker.hpp
@@ -11,8 +11,8 @@ class WorldPublisher : private utils::Publisher {
    public:
     WorldPublisher();
 
-    // Publishes the given world. Returns success
-    bool publish(const proto::State& world);
+    // Publishes the given world. Returns bytes sent, -1 on failure
+    std::size_t publish(const proto::State& world);
 };
 
 class WorldSubscriber : private rtt::net::utils::Subscriber {

--- a/include/utils/Publisher.hpp
+++ b/include/utils/Publisher.hpp
@@ -25,7 +25,7 @@ class Publisher {
    protected:
     /* Send a message of the specified type
      * @param message: Message to send.
-     * @returns bytes sent, or -1 on failure */
+     * @returns bytes sent, or 0 on failure */
     std::size_t send(const std::string &message);
 
    private:

--- a/include/utils/Publisher.hpp
+++ b/include/utils/Publisher.hpp
@@ -24,8 +24,9 @@ class Publisher {
 
    protected:
     /* Send a message of the specified type
-     * @param message: Message to send. */
-    bool send(const std::string &message);
+     * @param message: Message to send.
+     * @returns bytes sent, or -1 on failure */
+    std::size_t send(const std::string &message);
 
    private:
     zmqpp::context context;

--- a/src/RobotCommandsNetworker.cpp
+++ b/src/RobotCommandsNetworker.cpp
@@ -85,9 +85,10 @@ rtt::RobotCommands protoToRobotCommands(const proto::RobotCommands& protoCommand
 // Blue commands publisher
 RobotCommandsBluePublisher::RobotCommandsBluePublisher() : utils::Publisher(utils::ChannelType::ROBOT_COMMANDS_BLUE_CHANNEL) {}
 
-bool RobotCommandsBluePublisher::publish(const rtt::RobotCommands& commands) {
+std::size_t RobotCommandsBluePublisher::publish(const rtt::RobotCommands& commands) {
     auto protoRobotCommands = robotCommandsToProto(commands);
-    return this->send(protoRobotCommands.SerializeAsString());
+
+    return this->send(protoRobotCommands.SerializeAsString()) ? protoRobotCommands.ByteSizeLong() : -1;
 }
 
 // Blue commands subscriber
@@ -107,9 +108,9 @@ void RobotCommandsBlueSubscriber::onPublishedMessage(const std::string& message)
 // Yellow commands publisher
 RobotCommandsYellowPublisher::RobotCommandsYellowPublisher() : utils::Publisher(utils::ChannelType::ROBOT_COMMANDS_YELLOW_CHANNEL) {}
 
-bool RobotCommandsYellowPublisher::publish(const rtt::RobotCommands& commands) {
+std::size_t RobotCommandsYellowPublisher::publish(const rtt::RobotCommands& commands) {
     auto protoRobotCommands = robotCommandsToProto(commands);
-    return this->send(protoRobotCommands.SerializeAsString());
+    return this->send(protoRobotCommands.SerializeAsString()) ? protoRobotCommands.ByteSizeLong() : -1;
 }
 
 RobotCommandsYellowSubscriber::RobotCommandsYellowSubscriber(const std::function<void(const rtt::RobotCommands&)>& callback)

--- a/src/RobotCommandsNetworker.cpp
+++ b/src/RobotCommandsNetworker.cpp
@@ -88,7 +88,7 @@ RobotCommandsBluePublisher::RobotCommandsBluePublisher() : utils::Publisher(util
 std::size_t RobotCommandsBluePublisher::publish(const rtt::RobotCommands& commands) {
     auto protoRobotCommands = robotCommandsToProto(commands);
 
-    return this->send(protoRobotCommands.SerializeAsString()) ? protoRobotCommands.ByteSizeLong() : -1;
+    return this->send(protoRobotCommands.SerializeAsString());
 }
 
 // Blue commands subscriber
@@ -110,7 +110,7 @@ RobotCommandsYellowPublisher::RobotCommandsYellowPublisher() : utils::Publisher(
 
 std::size_t RobotCommandsYellowPublisher::publish(const rtt::RobotCommands& commands) {
     auto protoRobotCommands = robotCommandsToProto(commands);
-    return this->send(protoRobotCommands.SerializeAsString()) ? protoRobotCommands.ByteSizeLong() : -1;
+    return this->send(protoRobotCommands.SerializeAsString());
 }
 
 RobotCommandsYellowSubscriber::RobotCommandsYellowSubscriber(const std::function<void(const rtt::RobotCommands&)>& callback)

--- a/src/RobotFeedbackNetworker.cpp
+++ b/src/RobotFeedbackNetworker.cpp
@@ -101,9 +101,9 @@ rtt::RobotsFeedback protoFeedbackToRobotsFeedback(const proto::RobotsFeedback& p
 
 RobotFeedbackPublisher::RobotFeedbackPublisher() : utils::Publisher(utils::ChannelType::ROBOT_FEEDBACK_CHANNEL) {}
 
-bool RobotFeedbackPublisher::publish(const rtt::RobotsFeedback& feedback) {
+std::size_t RobotFeedbackPublisher::publish(const rtt::RobotsFeedback& feedback) {
     auto protoRobotsFeedback = feedbackToProto(feedback);
-    return this->send(protoRobotsFeedback.SerializeAsString());
+    return this->send(protoRobotsFeedback.SerializeAsString()) ? protoRobotsFeedback.ByteSizeLong() : -1;
 }
 
 RobotFeedbackSubscriber::RobotFeedbackSubscriber(const std::function<void(const rtt::RobotsFeedback&)>& callback)

--- a/src/RobotFeedbackNetworker.cpp
+++ b/src/RobotFeedbackNetworker.cpp
@@ -103,7 +103,7 @@ RobotFeedbackPublisher::RobotFeedbackPublisher() : utils::Publisher(utils::Chann
 
 std::size_t RobotFeedbackPublisher::publish(const rtt::RobotsFeedback& feedback) {
     auto protoRobotsFeedback = feedbackToProto(feedback);
-    return this->send(protoRobotsFeedback.SerializeAsString()) ? protoRobotsFeedback.ByteSizeLong() : -1;
+    return this->send(protoRobotsFeedback.SerializeAsString());
 }
 
 RobotFeedbackSubscriber::RobotFeedbackSubscriber(const std::function<void(const rtt::RobotsFeedback&)>& callback)

--- a/src/SettingsNetworker.cpp
+++ b/src/SettingsNetworker.cpp
@@ -5,7 +5,7 @@ namespace rtt::net {
 SettingsPublisher::SettingsPublisher() : utils::Publisher(utils::ChannelType::SETTINGS_CHANNEL) {}
 
 std::size_t SettingsPublisher::publish(const proto::Setting& settings) {
-    return this->send(settings.SerializeAsString()) ? settings.ByteSizeLong() : -1;
+    return this->send(settings.SerializeAsString());
 }
 
 SettingsSubscriber::SettingsSubscriber(const std::function<void(const proto::Setting&)>& callback)

--- a/src/SettingsNetworker.cpp
+++ b/src/SettingsNetworker.cpp
@@ -4,7 +4,9 @@ namespace rtt::net {
 
 SettingsPublisher::SettingsPublisher() : utils::Publisher(utils::ChannelType::SETTINGS_CHANNEL) {}
 
-bool SettingsPublisher::publish(const proto::Setting& settings) { return this->send(settings.SerializeAsString()); }
+std::size_t SettingsPublisher::publish(const proto::Setting& settings) {
+    return this->send(settings.SerializeAsString()) ? settings.ByteSizeLong() : -1;
+}
 
 SettingsSubscriber::SettingsSubscriber(const std::function<void(const proto::Setting&)>& callback)
     : utils::Subscriber(utils::ChannelType::SETTINGS_CHANNEL, [&](const std::string& message) { this->onPublishedMessage(message); }), callback(callback) {

--- a/src/SimulationConfigurationNetworker.cpp
+++ b/src/SimulationConfigurationNetworker.cpp
@@ -5,7 +5,7 @@ namespace rtt::net {
 SimulationConfigurationPublisher::SimulationConfigurationPublisher() : utils::Publisher(utils::ChannelType::SIMULATION_CONFIGURATION_CHANNEL) {}
 
 std::size_t SimulationConfigurationPublisher::publish(const proto::SimulationConfiguration& config) {
-    return this->send(config.SerializeAsString()) ? config.ByteSizeLong() : -1;
+    return this->send(config.SerializeAsString());
 }
 
 SimulationConfigurationSubscriber::SimulationConfigurationSubscriber(const std::function<void(const proto::SimulationConfiguration&)>& callback)

--- a/src/SimulationConfigurationNetworker.cpp
+++ b/src/SimulationConfigurationNetworker.cpp
@@ -4,7 +4,9 @@ namespace rtt::net {
 
 SimulationConfigurationPublisher::SimulationConfigurationPublisher() : utils::Publisher(utils::ChannelType::SIMULATION_CONFIGURATION_CHANNEL) {}
 
-bool SimulationConfigurationPublisher::publish(const proto::SimulationConfiguration& config) { return this->send(config.SerializeAsString()); }
+std::size_t SimulationConfigurationPublisher::publish(const proto::SimulationConfiguration& config) {
+    return this->send(config.SerializeAsString()) ? config.ByteSizeLong() : -1;
+}
 
 SimulationConfigurationSubscriber::SimulationConfigurationSubscriber(const std::function<void(const proto::SimulationConfiguration&)>& callback)
     : utils::Subscriber(utils::ChannelType::SIMULATION_CONFIGURATION_CHANNEL, [&](const std::string& message) { this->onPublishedMessage(message); }), callback(callback) {

--- a/src/WorldNetworker.cpp
+++ b/src/WorldNetworker.cpp
@@ -5,7 +5,7 @@ namespace rtt::net {
 WorldPublisher::WorldPublisher() : utils::Publisher(utils::ChannelType::WORLD_CHANNEL) {}
 
 std::size_t WorldPublisher::publish(const proto::State& world) {
-    return this->send(world.SerializeAsString()) ? world.ByteSizeLong() : -1;
+    return this->send(world.SerializeAsString());
 }
 
 WorldSubscriber::WorldSubscriber(const std::function<void(const proto::State&)>& callback)

--- a/src/WorldNetworker.cpp
+++ b/src/WorldNetworker.cpp
@@ -4,7 +4,9 @@ namespace rtt::net {
 
 WorldPublisher::WorldPublisher() : utils::Publisher(utils::ChannelType::WORLD_CHANNEL) {}
 
-bool WorldPublisher::publish(const proto::State& world) { return this->send(world.SerializeAsString()); }
+std::size_t WorldPublisher::publish(const proto::State& world) {
+    return this->send(world.SerializeAsString()) ? world.ByteSizeLong() : -1;
+}
 
 WorldSubscriber::WorldSubscriber(const std::function<void(const proto::State&)>& callback)
     : utils::Subscriber(utils::ChannelType::WORLD_CHANNEL, [&](const std::string& message) { this->onPublishedMessage(message); }), callback(callback) {

--- a/src/utils/Publisher.cpp
+++ b/src/utils/Publisher.cpp
@@ -11,7 +11,7 @@ std::size_t Publisher::send(const std::string& message) {
     zmqpp::message transmission;
     transmission << message;
 
-    return socket->send(transmission, true) ? message.length() : -1;
+    return socket->send(transmission, true) ? message.length() : 0;
 }
 
 }  // namespace rtt::net::utils

--- a/src/utils/Publisher.cpp
+++ b/src/utils/Publisher.cpp
@@ -7,11 +7,11 @@ Publisher::Publisher(const ChannelType channelType) : channel(CHANNELS.at(channe
     this->socket->bind(this->channel.getPublishAddress());
 }
 
-bool Publisher::send(const std::string& message) {
+std::size_t Publisher::send(const std::string& message) {
     zmqpp::message transmission;
     transmission << message;
 
-    return socket->send(transmission, true);
+    return socket->send(transmission, true) ? message.length() : -1;
 }
 
 }  // namespace rtt::net::utils


### PR DESCRIPTION
@rolfvdhulst found a [small bug in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/issues/66). A nice way to solve this would be to return the bytes sent instead of success when a publish function is called. This PR makes that change.
Other repos do depend on this mechanic, so this PR is co-dependent on:
- The [PR in AI](https://github.com/RoboTeamTwente/roboteam_ai/pull/1399)
- The [PR in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/pull/67)
- The [PR in World](https://github.com/RoboTeamTwente/roboteam_world/pull/80)